### PR TITLE
fixed likes on bbpress replies

### DIFF
--- a/inc/wp-ulike.php
+++ b/inc/wp-ulike.php
@@ -231,9 +231,12 @@
 	 */
 	function wp_ulike_bbpress($arg) {
 		//global variables
-		global $post,$wp_ulike_class,$wp_user_IP;
-		
-		$post_ID 		= $post->ID;
+		global $post,$wp_ulike_class,$wp_user_IP;          
+
+                // NOTICE! Understand what this does before running.
+                $replyId = bbp_get_reply_id();
+
+		$post_ID 		= !$replyId ? $post->ID : $replyId;
 		$get_post_meta 	= get_post_meta($post_ID, '_topicliked', true);
 		$get_like 		= $get_post_meta != '' ? $get_post_meta : 0;
 		$return_userID 	= $wp_ulike_class->get_reutrn_id();


### PR DESCRIPTION
Before it WP-Ulike considered the post-id for each bbpress reply, so even if i like a single reply it instead gave the like to the author's post
