### PR TITLE
Update wp-like.php to add UNSIGNED to user_id

### DIFF
--- a/wp-ulike.php
+++ b/wp-ulike.php
@@ -54,7 +54,7 @@ function wp_ulike_install() {
 				`post_id` int(11) NOT NULL,
 				`date_time` datetime NOT NULL,
 				`ip` varchar(30) NOT NULL,
-				`user_id` int(11) NOT NULL,
+				`user_id` int(11) UNSIGNED NOT NULL,
 				`status` varchar(15) NOT NULL,
 				PRIMARY KEY (`id`)
 			);";
@@ -72,7 +72,7 @@ function wp_ulike_install() {
 				`comment_id` int(11) NOT NULL,
 				`date_time` datetime NOT NULL,
 				`ip` varchar(30) NOT NULL,
-				`user_id` int(11) NOT NULL,
+				`user_id` int(11) UNSIGNED NOT NULL,
 				`status` varchar(15) NOT NULL,
 				PRIMARY KEY (`id`)
 			);";
@@ -90,7 +90,7 @@ function wp_ulike_install() {
 				`activity_id` int(11) NOT NULL,
 				`date_time` datetime NOT NULL,
 				`ip` varchar(30) NOT NULL,
-				`user_id` int(11) NOT NULL,
+				`user_id` int(11) UNSIGNED NOT NULL,
 				`status` varchar(15) NOT NULL,
 				PRIMARY KEY (`id`)
 			);";
@@ -108,7 +108,7 @@ function wp_ulike_install() {
 				`topic_id` int(11) NOT NULL,
 				`date_time` datetime NOT NULL,
 				`ip` varchar(30) NOT NULL,
-				`user_id` int(11) NOT NULL,
+				`user_id` int(11) UNSIGNED NOT NULL,
 				`status` varchar(15) NOT NULL,
 				PRIMARY KEY (`id`)
 			);";


### PR DESCRIPTION
Issue: Signed integers have a positive maximum value of 2,147,483,647, while ip2long has a maximum value of 4,294,967,295, so IP addresses over 127.255.255.255 are converted to 127.255.255.255.  Users that aren't logged in with IPs over 127.255.255.255 can like items multiple times and unlikes don't process properly for these users.

Solution: Updated wp-like.php to add UNSIGNED to user_id in all CREATE TABLE SQL statements, which will allow the column to store the appropriate maximum value.