### PR TITLE
Added a requested function to check if user has liked a post

### DIFF
--- a/inc/general-functions.php
+++ b/inc/general-functions.php
@@ -1537,6 +1537,34 @@ if( ! function_exists( 'wp_ulike_generate_user_id' ) ){
 	}
 }
 
+/**
+ * Function to check if user has liked post
+ *
+ * @author       	Jose Colina [hozerapha]
+ * @param         	String $user_ID, $post_ID
+ * @since         	3.4
+ * @return        	Boolean
+ */
+if(!function_exists('wp_ulike_user_liked_post')) {
+	function wp_ulike_user_liked_post($user_ID, $post_ID) {
+		// Global wordpress database object
+		global $wpdb;
+		// Get ULike settings
+		$wpu_settings = wp_ulike_get_post_settings_by_type('likeThis', $post_ID);
+		$table_name = $wpu_settings['table_name'];
+		$column_name = $wpu_settings['column_name'];
+		// Get number of likes in the post by the user
+		$results = $wpdb->get_results( "SELECT COUNT(id) AS total
+						FROM   ".$wpdb->prefix."$table_name
+						WHERE  $column_name = '$post_ID'
+						       AND status   = 'like'
+						       AND user_id = $user_ID"
+					);
+		// Return bool true if there is a like
+		return ($results[0]->total > 0);
+	}
+}
+
 /*******************************************************
   Templates
 *******************************************************/

--- a/inc/general-functions.php
+++ b/inc/general-functions.php
@@ -1542,7 +1542,7 @@ if( ! function_exists( 'wp_ulike_generate_user_id' ) ){
  *
  * @author       	Jose Colina [hozerapha]
  * @param         	String $user_ID, $post_ID
- * @since         	3.4
+ * @since         	> 3.5.1
  * @return        	Boolean
  */
 if(!function_exists('wp_ulike_user_liked_post')) {


### PR DESCRIPTION
Referencing issue #42, a function has been added, wp_ulike_user_liked_post, to check if an user has liked a post.

It can be used inside the loop with wp_ulike_user_liked_post(get_current_user_id(), get_the_ID())

Returns boolean true if the user liked the post, false if the user hasn't liked the post or if there's not a logged user. 