### PR TITLE
Fixed wrong date range in statistics widget

### DIFF
--- a/admin/classes/class-wp-ulike-stats.php
+++ b/admin/classes/class-wp-ulike-stats.php
@@ -183,6 +183,7 @@ if ( ! class_exists( 'wp_ulike_stats' ) ) {
 					SELECT DATE(date_time) AS labels,
 					count(date_time) AS counts
 					FROM %s
+					WHERE TO_DAYS(NOW()) - TO_DAYS(date_time) <= 30
 					GROUP BY labels
 					ASC LIMIT %d",
 					$this->wpdb->prefix . $table,


### PR DESCRIPTION
Merge request to add the fix in https://github.com/Alimir/wp-ulike/issues/59#issuecomment-526049117. Fixes #59.